### PR TITLE
Correctly terminated zerolog chains

### DIFF
--- a/app/daemon/main.go
+++ b/app/daemon/main.go
@@ -60,6 +60,6 @@ func main() {
 	log.Info().Msgf("Started daemon")
 
 	if err := d.Run(); err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Msg("")
 	}
 }

--- a/virtual/docker/docker.go
+++ b/virtual/docker/docker.go
@@ -57,12 +57,12 @@ func init() {
 	var err error
 	DefaultClient, err = docker.NewClient("unix:///var/run/docker.sock")
 	if err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Msg("")
 	}
 
 	DefaultLinkBridge, err = newDefaultBridge("hkn-bridge")
 	if err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Msg("Error creating default bridge")
 	}
 
 	rand.Seed(time.Now().Unix())

--- a/virtual/docker/docker_test.go
+++ b/virtual/docker/docker_test.go
@@ -21,7 +21,7 @@ var dockerClient, dockerErr = fdocker.NewClient("unix:///var/run/docker.sock")
 
 func init() {
 	if dockerErr != nil {
-		log.Fatal().Err(dockerErr)
+		log.Fatal().Err(dockerErr).Msg("")
 	}
 
 	zerolog.SetGlobalLevel(zerolog.Disabled)


### PR DESCRIPTION
Added the missing Msg() calls to some of zerolog chains.

Without these the error will not be reported and the program will not exit on a fatal error.

> It is very important to note that when using the zerolog chaining API, as shown above (log.Info().Msg("hello world"), the chain must have either the Msg or Msgf method call. If you forget to add either of these, the log will not occur and there is no compile time error to alert you of this.

[Source](https://github.com/rs/zerolog#simple-leveled-logging-example)