### PR TITLE
Fix dynamic flags #190

### DIFF
--- a/store/event.go
+++ b/store/event.go
@@ -160,6 +160,8 @@ func (t *Team) AddChallenge(c Challenge) {
 		t.ChalMap = map[Tag]Challenge{}
 	}
 	t.ChalMap[c.FlagTag] = c
+	log.Info().Str("FlagValue",c.FlagValue).Str("FlagTag", string(c.FlagTag)).Msg("From AddChallenge")
+
 }
 
 func (t *Team) DataConsent() bool {

--- a/svcs/ctfd/ctfd.go
+++ b/svcs/ctfd/ctfd.go
@@ -268,6 +268,9 @@ func (ctf *ctfd) configureInstance() error {
 
 		log.Debug().
 			Str("name", flag.Name).
+			Str("Flag Tag ",string(flag.Tag)).
+			Str("Flag Value",value).
+			Str("Flag Static",flag.Static).
 			Bool("static", flag.Static != "").
 			Uint("points", flag.Points).
 			Msg("Flag created")

--- a/svcs/ctfd/flagpool.go
+++ b/svcs/ctfd/flagpool.go
@@ -87,7 +87,7 @@ func (fp *FlagPool) GetTagByIdentifier(id int) (store.Tag, error) {
 	return conf.Tag, nil
 }
 
-func (fp *FlagPool) TranslateFlagForTeam(t store.Team, cid int, value string) string {
+func (fp *FlagPool) TranslateFlagForTeam(t *store.Team, cid int, value string) string {
 	fp.m.RLock()
 	defer fp.m.RUnlock()
 

--- a/svcs/ctfd/flagpool.go
+++ b/svcs/ctfd/flagpool.go
@@ -93,15 +93,11 @@ func (fp *FlagPool) TranslateFlagForTeam(t *store.Team, cid int, value string) s
 
 	chal, ok := fp.ids[cid]
 	if !ok {
-		return ""
-	}
-
-	if chal.IsStatic() {
-		return chal.CTFdFlag
+		return "Challenge cannot be retrievend from flag pool ! "
 	}
 
 	if err := t.IsCorrectFlag(chal.Tag, value); err != nil {
-		return ""
+		return "Error happened on checking flag ! "+ err.Error()
 	}
 
 	return chal.CTFdFlag

--- a/svcs/ctfd/interception.go
+++ b/svcs/ctfd/interception.go
@@ -435,9 +435,10 @@ func (cfi *checkFlagInterception) Intercept(next http.Handler) http.Handler {
 		chalNumStr := matches[1]
 		cid, _ := strconv.Atoi(chalNumStr)
 
+
 		originalFlag := r.FormValue("key")
 
-		translatedFlag := cfi.flagPool.TranslateFlagForTeam(t, cid, originalFlag)
+		translatedFlag := cfi.flagPool.TranslateFlagForTeam(&t, cid, originalFlag)
 
 		r.Form.Set("key", translatedFlag)
 


### PR DESCRIPTION
- `teamQueue` converted to pointer.
- `team.store` accessed with pointer. 
 
The main problem with dynamic flags was retrieving challenge maps of teams, in order to get them in proper way given variables above changed into pointer. In addition, the following check is removed from translateFlagForTeam function  [removed check](https://github.com/aau-network-security/haaukins/blob/0544e21ed5b0d6b37ce77bf1b0a3213b25612b35/svcs/ctfd/flagpool.go#L99) because when the flag is static, it returns the flag, whatever user type into challenge input page. 
The flag will already be checked with `isCorrectFlag` function, so do not need to check whether it is static or dynamic. 
