### PR TITLE
travis configuration is updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 
 language: go
 go:
-- '1.11'
+- '1.13'
 
 services:
 - docker
@@ -15,7 +15,7 @@ cache:
 env:
   global:
     GIT_TAG=$(git describe --tags)
-    GOCACHE=off
+
 
 before_install:
 - openssl aes-256-cbc -K $encrypted_a30037d67e8c_key -iv $encrypted_a30037d67e8c_iv -in travis_deploy_key.enc -out ./travis_deploy_key -d


### PR DESCRIPTION
Go Version is updated to 1.13 
`GOCACHE=off` removed  (not valid on go1.13)
