### PR TITLE
homebrew formula added to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -119,3 +119,15 @@ checksum:
   # Accepted options are sha256, sha512, sha1, crc32, md5, sha224 and sha384.
   # Default is sha256.
   algorithm: sha256
+
+brews:
+  - github:
+      owner: mrturkmen06
+      name: homebrew-haaukins
+    folder: Formula
+    homepage:  https://github.com/aau-network-security/haaukins
+    description: Haaukins CLI
+    install: |
+      bin.install "hkn"
+    test: |
+      system "#{bin}/hkn --help"


### PR DESCRIPTION
- I have created `homebrew` into Haaukins, which means that MacOS users will be able to update or install Haaukins command line client through terminal no need to download from `releases` page of the project. 

