### PR TITLE
fixing Error creating new Lab: Tag already exists

### DIFF
--- a/exercise/environment.go
+++ b/exercise/environment.go
@@ -66,12 +66,6 @@ func (ee *environment) Add(ctx context.Context, confs ...store.Exercise) error {
 			return MissingTagsErr
 		}
 
-		for _, t := range conf.Tags {
-			if _, ok := ee.tags[t]; ok {
-				return DuplicateTagErr
-			}
-		}
-
 		e := NewExercise(conf, dockerHost{}, ee.lib, ee.network, ee.dnsAddr)
 		if err := e.Create(ctx); err != nil {
 			return err

--- a/exercise/environment.go
+++ b/exercise/environment.go
@@ -66,6 +66,12 @@ func (ee *environment) Add(ctx context.Context, confs ...store.Exercise) error {
 			return MissingTagsErr
 		}
 
+		for _, t := range conf.Tags {
+			if _, ok := ee.tags[t]; ok {
+				return DuplicateTagErr
+			}
+		}
+
 		e := NewExercise(conf, dockerHost{}, ee.lib, ee.network, ee.dnsAddr)
 		if err := e.Create(ctx); err != nil {
 			return err


### PR DESCRIPTION
i have compared the `hub.go`, `lab.go`, `environment.go` with the `1.7.0` version and there is not any changes with this branch.
in order to be sure that the error has been fixed we have to run a big event in the test server