### PR TITLE
remove duplicate tags in event creation

### DIFF
--- a/daemon/event.go
+++ b/daemon/event.go
@@ -46,9 +46,10 @@ func (d *daemon) CreateEvent(req *pb.CreateEventRequest, resp pb.Daemon_CreateEv
 		Str("finishTime", req.FinishTime).
 		Msg("create event")
 	now := time.Now()
+	uniqueExercisesList := removeDuplicates(req.Exercises)
 
-	tags := make([]store.Tag, len(req.Exercises))
-	for i, s := range req.Exercises {
+	tags := make([]store.Tag, len(uniqueExercisesList))
+	for i, s := range uniqueExercisesList {
 		t, err := store.NewTag(s)
 		if err != nil {
 			return err
@@ -237,4 +238,19 @@ func (d *daemon) SuspendEvent(req *pb.SuspendEventRequest, server pb.Daemon_Susp
 	d.eventPool.handlers[eventTag] = event.Handler()
 	event.SetStatus(int32(guacamole.Running))
 	return nil
+}
+
+//removeDuplicates removes duplicated values in given list
+// used incoming CreateEventRequest
+func removeDuplicates(exercises []string) []string {
+	k := make(map[string]bool)
+	var uniqueExercises []string
+
+	for _, e := range exercises {
+		if _, v := k[e]; !v {
+			k[e] = true
+			uniqueExercises = append(uniqueExercises, e)
+		}
+	}
+	return uniqueExercises
 }

--- a/daemon/event_test.go
+++ b/daemon/event_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"reflect"
 	"testing"
 	"time"
 
@@ -323,6 +324,24 @@ func TestListEvents(t *testing.T) {
 				t.Fatalf("unexpected amount of events (expected: %d), received: %d", tc.count, n)
 			}
 
+		})
+	}
+}
+
+func Test_removeDuplicates(t *testing.T) {
+	tests := []struct {
+		name      string
+		exercises []string
+		want      []string
+	}{
+		{name: "List with duplicated values", exercises: []string{"test1", "test", "test2", "test1", "test3", "test23"}, want: []string{"test1", "test", "test2", "test3", "test23"}},
+		{name: "List without duplicated values", exercises: []string{"test", "test1", "test2"}, want: []string{"test", "test1", "test2"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeDuplicates(tt.exercises); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("removeDuplicates() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Ahmet Turkmen <f.ahmet.turkmen@icloud.com>

- Duplicated tags from incoming create event request deleted. 