### PR TITLE
fixed event status

### DIFF
--- a/svcs/guacamole/event.go
+++ b/svcs/guacamole/event.go
@@ -30,8 +30,8 @@ import (
 const (
 	displayTimeFormat = "2006-01-02 15:04:05"
 	Running           = State(0)
-	Booked            = State(1) // todo: will be added
-	Suspended         = State(2)
+	Suspended         = State(1)
+	Booked            = State(2)
 	Closed            = State(3)
 	Error             = State(4)
 )


### PR DESCRIPTION
i have found another error apart from this one that i have fixed.
When haaukins either crash or is stopped with an event in `suspended` status, you are not able to `resume` that event when haaukins starts again.
You can test it either from the `cli` or the `webclient`.