### PR TITLE
add waitgroups to suspend function

### DIFF
--- a/lab/hub.go
+++ b/lab/hub.go
@@ -165,13 +165,17 @@ func (h *hub) Close() error {
 
 func (h *hub) Suspend(ctx context.Context) error {
 	var suspendError error
-	go func() {
-		for _, l := range h.labs {
+	var wg sync.WaitGroup
+	for _, l := range h.labs {
+		wg.Add(1)
+		go func() {
 			if err := l.Suspend(ctx); err != nil {
 				err = suspendError
 			}
-		}
-	}()
+			wg.Done()
+		}()
+		wg.Wait()
+	}
 
 	return suspendError
 }
@@ -179,15 +183,19 @@ func (h *hub) Suspend(ctx context.Context) error {
 func (h *hub) Resume(ctx context.Context) error {
 
 	var resumeError error
+	var wg sync.WaitGroup
 
-	go func() {
-
-		for _, l := range h.labs {
+	for _, l := range h.labs {
+		wg.Add(1)
+		go func() {
 			if err := l.Resume(ctx); err != nil {
 				err = resumeError
 			}
-		}
-	}()
+			wg.Done()
+		}()
+		wg.Wait()
+
+	}
 
 	return resumeError
 }

--- a/virtual/vbox/vbox.go
+++ b/virtual/vbox/vbox.go
@@ -152,7 +152,7 @@ func (vm *vm) Suspend(ctx context.Context) error {
 	if err != nil {
 		log.Error().
 			Str("ID", vm.id).
-			Msgf("Failed to suspend VM: %s", err)
+			Msgf("Failed to suspend VM: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Ahmet Turkmen <f.ahmet.turkmen@icloud.com>

- We have noticed a bug regarding to suspending vms, which is caused by not properly handled goroutines therefore, an update for fixing the error has been proposed in this pull request. 

- Tested for both individual teams and events as well.  