### PR TITLE
Hotfix/randomly disabled chals problem #000

### DIFF
--- a/store/team.go
+++ b/store/team.go
@@ -242,7 +242,6 @@ func NewTeam(email, name, password, id, hashedPass, solvedChalsDB string,
 	lastAccessedT time.Time, disabledExs, allChallenges map[string][]string, dbc pbc.StoreClient) *Team {
 	disabledChals := CopyMap(disabledExs)
 	allChals := CopyMap(allChallenges)
-	log.Debug().Interface("Disabled Exercises", disabledExs).Msg(" New Team disabled exercises !!")
 	var hPass []byte
 	if hashedPass == "" {
 		hPass, _ = bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)

--- a/store/team.go
+++ b/store/team.go
@@ -240,6 +240,9 @@ type TeamChallenge struct {
 
 func NewTeam(email, name, password, id, hashedPass, solvedChalsDB string,
 	lastAccessedT time.Time, disabledExs, allChallenges map[string][]string, dbc pbc.StoreClient) *Team {
+	disabledChals := CopyMap(disabledExs)
+	allChals := CopyMap(allChallenges)
+	log.Debug().Interface("Disabled Exercises", disabledExs).Msg(" New Team disabled exercises !!")
 	var hPass []byte
 	if hashedPass == "" {
 		hPass, _ = bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
@@ -267,8 +270,8 @@ func NewTeam(email, name, password, id, hashedPass, solvedChalsDB string,
 		lastAccess:         lastAccessedT,
 		vpnKeys:            map[int]string{},
 		isLabAssigned:      false,
-		disabledChallenges: disabledExs,
-		allChallenges:      allChallenges,
+		disabledChallenges: disabledChals,
+		allChallenges:      allChals,
 	}
 }
 
@@ -614,4 +617,15 @@ func (t *Team) CorrectedAssignedLab() {
 	t.m.Lock()
 	defer t.m.Unlock()
 	t.isLabAssigned = true
+}
+
+func CopyMap(m map[string][]string) map[string][]string {
+	nm := make(map[string][]string)
+	for k, v := range m {
+		_, ok := nm[k]
+		if !ok {
+			nm[k] = v
+		}
+	}
+	return nm
 }

--- a/store/team_test.go
+++ b/store/team_test.go
@@ -1,0 +1,30 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCopyMap(t *testing.T) {
+	m1 := map[string][]string{
+		"apple":  {"a", "p", "p", "l", "e"},
+		"banana": {"b", "a", "n", "a", "n", "a"},
+	}
+
+	m2 := CopyMap(m1)
+
+	m1["apple"] = []string{"n", "o", "t", "a", "p", "p", "l", "e"}
+	delete(m1, "apple")
+	expected := map[string][]string{"banana": {"b", "a", "n", "a", "n", "a"}}
+
+	if !reflect.DeepEqual(m1, expected) {
+		t.Fatalf("Maps are not matching as expected, Expected: %v Actual: %v ", expected, m1)
+	}
+	expected = map[string][]string{
+		"apple":  {"a", "p", "p", "l", "e"},
+		"banana": {"b", "a", "n", "a", "n", "a"},
+	}
+	if !reflect.DeepEqual(m2, expected) {
+		t.Fatalf("Maps are not matching as expected, Expected: %v Actual: %v ", expected, m1)
+	}
+}

--- a/store/team_test.go
+++ b/store/team_test.go
@@ -25,6 +25,6 @@ func TestCopyMap(t *testing.T) {
 		"banana": {"b", "a", "n", "a", "n", "a"},
 	}
 	if !reflect.DeepEqual(m2, expected) {
-		t.Fatalf("Maps are not matching as expected, Expected: %v Actual: %v ", expected, m1)
+		t.Fatalf("Maps are not matching as expected, Expected: %v Actual: %v ", expected, m2)
 	}
 }

--- a/svcs/amigo/amigo.go
+++ b/svcs/amigo/amigo.go
@@ -687,10 +687,13 @@ func (am *Amigo) handleSignupPOST(hook func(t *store.Team) error) http.HandlerFu
 				return
 			}
 		}
+		disabledChals := store.CopyMap(am.TeamStore.DisabledChallenges)
+		allChals := store.CopyMap(am.TeamStore.AllChallenges)
+
 		// email removed  due to GDPR
 		t := store.NewTeam("", strings.TrimSpace(params.TeamName), params.Password,
 			"", "", "", time.Now().UTC(),
-			am.TeamStore.DisabledChallenges, am.TeamStore.AllChallenges, nil)
+			disabledChals, allChals, nil)
 
 		if err := am.TeamStore.SaveTeam(t); err != nil {
 			displayErr(w, params, err)


### PR DESCRIPTION
The issue was occurring due to the fact that in Golang, when we are using maps, we are actually referencing them. In case of creating NewTeam, new set of maps should be created to be passed to NewTeam function in order to avoid further problems. 