### PR TITLE
Feature/enable sftp #690

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Rechaptcha         string                           `yaml:"recaptcha-key,omitempty"`
 	APICreds           APICreds                         `yaml:"api-creds,omitempty"`
 	DockerRepositories []dockerclient.AuthConfiguration `yaml:"docker-repositories,omitempty"`
+	FileTransferRoot   FileTransferConf                 `yaml:"file-transfer-root,omitempty"`
 }
 
 type APICreds struct {
@@ -67,4 +68,8 @@ type Files struct {
 	UsersFile     string `yaml:"users-file,omitempty"`
 	ExercisesFile string `yaml:"exercises-file,omitempty"`
 	FrontendsFile string `yaml:"frontends-file,omitempty"`
+}
+
+type FileTransferConf struct {
+	Path string `yaml:"path"`
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -211,6 +211,10 @@ func NewConfigFromFile(path string) (*Config, error) {
 }
 
 func New(conf *Config) (*daemon, error) {
+	err := vbox.CreateFileTransferRoot(conf.FileTransferRoot.Path)
+	if err != nil {
+		log.Fatal().Msgf("Error while creating file transfer root: %s", err)
+	}
 	uf, err := store.NewUserFile(conf.ConfFiles.UsersFile)
 	if err != nil {
 		return nil, errors.Wrap(err, fmt.Sprintf("unable to read users file: %s", conf.ConfFiles.UsersFile))

--- a/daemon/event.go
+++ b/daemon/event.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/aau-network-security/haaukins/virtual/vbox"
 	"math"
 	"math/rand"
 	"net/http"
@@ -375,6 +376,10 @@ func (d *daemon) StopEvent(req *pb.StopEventRequest, resp pb.Daemon_StopEventSer
 		}
 
 		if (user.NPUser && user.Username == createdBy) || !user.NPUser {
+			// remove the corrosponding event folder
+			if err := vbox.RemoveEventFolder(string(evtag)); err != nil {
+				//do nothing
+			}
 			_, err := d.dbClient.SetEventStatus(ctx, &pbc.SetEventStatusRequest{EventTag: string(evtag), Status: Closed})
 			if err != nil {
 				return fmt.Errorf("error happened on setting up status of event, err: %v", err)

--- a/daemon/instance.go
+++ b/daemon/instance.go
@@ -45,7 +45,7 @@ func (d *daemon) ResetFrontends(req *pb.ResetFrontendsRequest, stream pb.Daemon_
 				continue
 			}
 
-			if err := lab.ResetFrontends(stream.Context()); err != nil {
+			if err := lab.ResetFrontends(stream.Context(), string(evtag), reqTeam.Id); err != nil {
 				return err
 			}
 			stream.Send(&pb.ResetTeamStatus{TeamId: reqTeam.Id, Status: "ok"})
@@ -61,7 +61,7 @@ func (d *daemon) ResetFrontends(req *pb.ResetFrontendsRequest, stream pb.Daemon_
 			continue
 		}
 
-		if err := lab.ResetFrontends(stream.Context()); err != nil {
+		if err := lab.ResetFrontends(stream.Context(), string(evtag), t.ID()); err != nil {
 			return err
 		}
 		stream.Send(&pb.ResetTeamStatus{TeamId: t.ID(), Status: "ok"})

--- a/lab/lab.go
+++ b/lab/lab.go
@@ -112,7 +112,7 @@ type Lab interface {
 	Suspend(context.Context) error
 	Resume(context.Context) error
 	Environment() exercise.Environment
-	ResetFrontends(ctx context.Context) error
+	ResetFrontends(ctx context.Context, eventTag, teamId string) error
 	RdpConnPorts() []uint
 	Tag() string
 	AddChallenge(ctx context.Context, confs ...store.Exercise) error
@@ -190,7 +190,7 @@ func (l *lab) Environment() exercise.Environment {
 	return l.environment
 }
 
-func (l *lab) ResetFrontends(ctx context.Context) error {
+func (l *lab) ResetFrontends(ctx context.Context, eventTag, teamId string) error {
 	var errs []error
 	for p, vmConf := range l.frontends {
 		err := vmConf.vm.Close()
@@ -209,6 +209,11 @@ func (l *lab) ResetFrontends(ctx context.Context) error {
 		if err != nil {
 			errs = append(errs, err)
 			continue
+		}
+
+		err = vbox.CreateFolderLink(vm.Info().Id, eventTag, teamId)
+		if err != nil {
+			log.Logger.Debug().Msgf("Error creating shared folder link after vm reset: %s", err)
 		}
 	}
 

--- a/svcs/guacamole/event.go
+++ b/svcs/guacamole/event.go
@@ -696,8 +696,8 @@ func (ev *event) createGuacConn(t *store.Team, lab lab.Lab) error {
 	enableWallPaper := true
 	enableDrive := true
 	createDrivePath := true
-	//todo get drivepath from event tag path
-	drivePath := vbox.FileTransferRoot + "/" + string(ev.store.Tag) + "/" + t.ID()
+	// Drive path is the home folder inside the docker guacamole
+	drivePath := "/home/" + t.ID()
 	rdpPorts := lab.RdpConnPorts()
 	if n := len(rdpPorts); n == 0 {
 		log.

--- a/svcs/guacamole/event.go
+++ b/svcs/guacamole/event.go
@@ -696,6 +696,7 @@ func (ev *event) createGuacConn(t *store.Team, lab lab.Lab) error {
 	enableWallPaper := true
 	enableDrive := true
 	createDrivePath := true
+	//todo get drivepath from event tag path
 	drivePath := "/home/" + t.ID()
 	rdpPorts := lab.RdpConnPorts()
 	if n := len(rdpPorts); n == 0 {

--- a/svcs/guacamole/event.go
+++ b/svcs/guacamole/event.go
@@ -926,7 +926,7 @@ func (ev *event) Handler() http.Handler {
 		if !ok {
 			return fmt.Errorf("Not found suitable team for given id: %s", t.ID())
 		}
-		if err := teamLab.ResetFrontends(context.Background()); err != nil {
+		if err := teamLab.ResetFrontends(context.Background(), string(ev.store.Tag), t.ID()); err != nil {
 			return fmt.Errorf("Reset frontends hook error %v", err)
 		}
 		return nil

--- a/svcs/guacamole/event.go
+++ b/svcs/guacamole/event.go
@@ -748,14 +748,11 @@ func (ev *event) createGuacConn(t *store.Team, lab lab.Lab) error {
 	}
 
 	instanceInfo := lab.InstanceInfo()
-	err = vbox.CreateUserFolder(t.ID(), string(ev.store.Tag))
-	if err != nil {
-		return err
-	}
-	err = vbox.CreateFolderLink(instanceInfo[0].Id, string(ev.store.Tag), t.ID())
-	if err != nil {
-		return err
-	}
+	// Will not handle error below since this is not a critical function
+	vbox.CreateUserFolder(t.ID(), string(ev.store.Tag))
+
+	vbox.CreateFolderLink(instanceInfo[0].Id, string(ev.store.Tag), t.ID())
+
 
 	return nil
 }

--- a/svcs/guacamole/guacamole.go
+++ b/svcs/guacamole/guacamole.go
@@ -662,7 +662,6 @@ func (guac *guacamole) CreateRDPConn(opts CreateRDPConnOpts) error {
 
 	action := func(t string) (*http.Response, error) {
 		endpoint := guac.baseUrl() + "/guacamole/api/session/data/mysql/connections?token=" + t
-		log.Debug().Msgf("Message send to guacendpoint: %s", jsonData)
 		req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(jsonData))
 		if err != nil {
 			return nil, err

--- a/svcs/guacamole/guacamole.go
+++ b/svcs/guacamole/guacamole.go
@@ -142,7 +142,7 @@ func (guac *guacamole) GetAdminPass() string {
 	return guac.conf.AdminPass
 }
 
-//TODO choose another path for mount
+//TODO choose another path for mount, Create new path when making a new event.
 func (guac *guacamole) create(ctx context.Context) error {
 	containers := map[string]docker.Container{}
 	containers["guacd"] = docker.NewContainer(docker.ContainerConfig{

--- a/svcs/guacamole/guacamole.go
+++ b/svcs/guacamole/guacamole.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/aau-network-security/haaukins/virtual/vbox"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -19,6 +18,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/aau-network-security/haaukins/virtual/vbox"
 
 	"github.com/aau-network-security/haaukins/store"
 
@@ -157,7 +158,7 @@ func (guac *guacamole) create(ctx context.Context, eventTag string) error {
 			"hkn": "guacamole_guacd",
 		},
 		Mounts: []string{
-			vbox.FileTransferRoot + "/" + eventTag + ":/home/",
+			vbox.FileTransferRoot + "/" + eventTag + "/:/home/",
 		},
 	})
 

--- a/svcs/guacamole/guacamole.go
+++ b/svcs/guacamole/guacamole.go
@@ -142,6 +142,7 @@ func (guac *guacamole) GetAdminPass() string {
 	return guac.conf.AdminPass
 }
 
+//TODO choose another path for mount
 func (guac *guacamole) create(ctx context.Context) error {
 	containers := map[string]docker.Container{}
 	containers["guacd"] = docker.NewContainer(docker.ContainerConfig{
@@ -149,6 +150,9 @@ func (guac *guacamole) create(ctx context.Context) error {
 		UseBridge: true,
 		Labels: map[string]string{
 			"hkn": "guacamole_guacd",
+		},
+		Mounts: []string{
+			"/home/mikkel/Desktop/arbejde/Haaukinsdev/haaukins/data/:/home/",
 		},
 	})
 
@@ -565,6 +569,7 @@ type createRDPConnConf struct {
 	SFTPAliveInterval        *uint   `json:"sftp-server-alive-interval"`
 	SwapRedBlue              *bool   `json:"swap-red-blue"`
 	CreateDrivePath          *bool   `json:"create-drive-path"`
+	DrivePath                *string `json:"drive-path"`
 	Username                 *string `json:"username,omitempty"`
 	Password                 *string `json:"password,omitempty"`
 }
@@ -581,6 +586,9 @@ type CreateRDPConnOpts struct {
 	ResolutionHeight uint
 	MaxConn          uint
 	ColorDepth       uint
+	EnableDrive      *bool
+	CreateDrivePath  *bool
+	DrivePath        *string
 }
 
 func (guac *guacamole) CreateRDPConn(opts CreateRDPConnOpts) error {
@@ -622,6 +630,9 @@ func (guac *guacamole) CreateRDPConn(opts CreateRDPConnOpts) error {
 		Username:        opts.Username,
 		Password:        opts.Password,
 		EnableWallpaper: opts.EnableWallPaper,
+		EnableDrive:     opts.EnableDrive,
+		CreateDrivePath: opts.CreateDrivePath,
+		DrivePath:       opts.DrivePath,
 	}
 
 	data := struct {
@@ -645,7 +656,7 @@ func (guac *guacamole) CreateRDPConn(opts CreateRDPConnOpts) error {
 
 	action := func(t string) (*http.Response, error) {
 		endpoint := guac.baseUrl() + "/guacamole/api/session/data/mysql/connections?token=" + t
-
+		log.Debug().Msgf("Message send to guacendpoint: %s", jsonData)
 		req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(jsonData))
 		if err != nil {
 			return nil, err

--- a/virtual/vbox/vbox.go
+++ b/virtual/vbox/vbox.go
@@ -528,19 +528,48 @@ func CreateFileTransferRoot(path string) error {
 	return nil
 }
 
-func CreateEventFolder(tag store.Tag) (string, error) {
-	path := FileTransferRoot + "/" + string(tag)
+func CreateEventFolder(tag string) error {
+	path := FileTransferRoot + "/" + tag
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		//If path exists
 		log.Info().Str("event-root", path).Msg("Event root already exists... Continuing.")
-		return path, nil
+		return nil
 	}
 	log.Info().Str("event-root", path).Msg("Event root does not exists... Creating folder")
 	err := os.MkdirAll(path, os.ModePerm)
 	if err != nil {
 		log.Warn().Msgf("Error creating event root: %s", err)
-		return "", err
+		return err
 	}
 	log.Info().Msg("Event root succesfully created!")
-	return path, nil
+	return nil
+}
+
+func CreateUserFolder(teamId string, eventTag string) error {
+	path := FileTransferRoot + "/" + eventTag + "/" + teamId
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		//If path exists
+		log.Info().Str("User-folder", path).Msg("User-folder already exists... Continuing.")
+		return nil
+	}
+	log.Info().Str("User-folder", path).Msg("User-folder does not exists... Creating folder")
+	err := os.MkdirAll(path, os.ModePerm)
+	if err != nil {
+		log.Warn().Msgf("Error creating User-folder: %s", err)
+		return err
+	}
+	log.Info().Msg("User-folder succesfully created!")
+	return nil
+}
+
+func CreateFolderLink(vm string, eventTag string, teamId string) error {
+	log.Debug().Msgf("Vbox id: v%", vm)
+	log.Debug().Msgf("Trying to create shared folder for vm: %d", vm)
+	//todo Figure out a way to add the new folder and general setup of filetransfer folder and how to manage its content.
+	_, err := VBoxCmdContext(context.Background(), "sharedfolder", "add", vm, "--name", "filetransfer", "-hostpath", FileTransferRoot+"/"+eventTag+"/"+teamId, "-transient", "-automount")
+	if err != nil {
+		log.Warn().Msgf("Error creating shared folder: %s", err)
+		return err
+	}
+	return nil
 }

--- a/virtual/vbox/vbox.go
+++ b/virtual/vbox/vbox.go
@@ -555,6 +555,23 @@ func CreateEventFolder(tag string) error {
 	return nil
 }
 
+func RemoveEventFolder(eventTag string) error {
+	path := FileTransferRoot + "/" + eventTag
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		//If path exists
+		log.Info().Str("Event-folder", path).Msg("Event-folder exists... Deleting.")
+		err := os.RemoveAll(path)
+		if err != nil {
+			log.Warn().Msgf("Error deleting event folder: %s with error: %s", path, err)
+			return err
+		}
+		return nil
+	} else {
+		log.Info().Str("Event-folder", path).Msg("Event-folder does not exists... Continueing")
+		return nil
+	}
+}
+
 func CreateUserFolder(teamId string, eventTag string) error {
 	path := FileTransferRoot + "/" + eventTag + "/" + teamId
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
@@ -578,8 +595,7 @@ func CreateUserFolder(teamId string, eventTag string) error {
 }
 
 func CreateFolderLink(vm string, eventTag string, teamId string) error {
-	log.Debug().Msgf("Vbox id: v%", vm)
-	log.Debug().Msgf("Trying to create shared folder for vm: %d", vm)
+	log.Debug().Msgf("Trying to link shared folder to vm: %s", vm)
 	//todo Figure out a way to add the new folder and general setup of filetransfer folder and how to manage its content.
 	_, err := VBoxCmdContext(context.Background(), "sharedfolder", "add", vm, "--name", "filetransfer", "-hostpath", FileTransferRoot+"/"+eventTag+"/"+teamId, "-transient", "-automount")
 	if err != nil {

--- a/virtual/vbox/vbox.go
+++ b/virtual/vbox/vbox.go
@@ -41,6 +41,8 @@ const (
 	vboxShowVMInfo   = "showvminfo"
 )
 
+var FileTransferRoot string
+
 func init() {
 	zerolog.SetGlobalLevel(zerolog.Disabled)
 }
@@ -502,4 +504,38 @@ func VBoxCmdContext(ctx context.Context, cmd string, cmds ...string) ([]byte, er
 	}
 
 	return out, nil
+}
+
+func CreateFileTransferRoot(path string) error {
+	FileTransferRoot = path
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		//If path exists
+		log.Info().Str("transfer-root", path).Msg("File transfer root already exists... Continuing.")
+		return nil
+	}
+	log.Info().Str("transfer-root", path).Msg("File transfer root does not exists... Creating folder")
+	err := os.MkdirAll(path, os.ModePerm)
+	if err != nil {
+		log.Warn().Msgf("Error creating file transfer root: %s", err)
+		return err
+	}
+	log.Info().Msg("File transfer root succesfully created!")
+	return nil
+}
+
+func CreateEventFolder(tag store.Tag) (string, error) {
+	path := FileTransferRoot + "/" + string(tag)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		//If path exists
+		log.Info().Str("event-root", path).Msg("Event root already exists... Continuing.")
+		return path, nil
+	}
+	log.Info().Str("event-root", path).Msg("Event root does not exists... Creating folder")
+	err := os.MkdirAll(path, os.ModePerm)
+	if err != nil {
+		log.Warn().Msgf("Error creating event root: %s", err)
+		return "", err
+	}
+	log.Info().Msg("Event root succesfully created!")
+	return path, nil
 }

--- a/virtual/vbox/vbox.go
+++ b/virtual/vbox/vbox.go
@@ -519,9 +519,14 @@ func CreateFileTransferRoot(path string) error {
 		return nil
 	}
 	log.Info().Str("transfer-root", path).Msg("File transfer root does not exists... Creating folder")
-	err := os.MkdirAll(path, os.ModePerm)
+	err := os.MkdirAll(path, 0777)
 	if err != nil {
 		log.Warn().Msgf("Error creating file transfer root: %s", err)
+		return err
+	}
+	err = os.Chmod(path, os.ModePerm)
+	if err != nil {
+		log.Warn().Msgf("Error setting folder perms on: %s error: %s", path, err)
 		return err
 	}
 	log.Info().Msg("File transfer root succesfully created!")
@@ -541,6 +546,11 @@ func CreateEventFolder(tag string) error {
 		log.Warn().Msgf("Error creating event root: %s", err)
 		return err
 	}
+	err = os.Chmod(path, os.ModePerm)
+	if err != nil {
+		log.Warn().Msgf("Error setting folder perms on: %s error: %s", path, err)
+		return err
+	}
 	log.Info().Msg("Event root succesfully created!")
 	return nil
 }
@@ -553,9 +563,14 @@ func CreateUserFolder(teamId string, eventTag string) error {
 		return nil
 	}
 	log.Info().Str("User-folder", path).Msg("User-folder does not exists... Creating folder")
-	err := os.MkdirAll(path, os.ModePerm)
+	err := os.MkdirAll(path, 0777)
 	if err != nil {
 		log.Warn().Msgf("Error creating User-folder: %s", err)
+		return err
+	}
+	err = os.Chmod(path, os.ModePerm)
+	if err != nil {
+		log.Warn().Msgf("Error setting folder perms on: %s error: %s", path, err)
 		return err
 	}
 	log.Info().Msg("User-folder succesfully created!")

--- a/virtual/vbox/vbox.go
+++ b/virtual/vbox/vbox.go
@@ -259,6 +259,11 @@ func SetLocalRDP(ip string, port uint) VMOpt {
 			return err
 		}
 
+		_, err = VBoxCmdContext(ctx, vboxModVM, vm.id, "--vrdemulticon", "on")
+		if err != nil {
+			return err
+		}
+
 		return nil
 	}
 }

--- a/virtual/vbox/vbox.go
+++ b/virtual/vbox/vbox.go
@@ -599,7 +599,7 @@ func CreateFolderLink(vm string, eventTag string, teamId string) error {
 	//todo Figure out a way to add the new folder and general setup of filetransfer folder and how to manage its content.
 	_, err := VBoxCmdContext(context.Background(), "sharedfolder", "add", vm, "--name", "filetransfer", "-hostpath", FileTransferRoot+"/"+eventTag+"/"+teamId, "-transient", "-automount")
 	if err != nil {
-		log.Warn().Msgf("Error creating shared folder: %s", err)
+		log.Warn().Msgf("Error creating shared folder link: %s", err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
By manipulating mounts and vbox shared folders i can create a link between each guac event home folder. 
Each user will get their own folder which they can upload files to via guacamole.

To upload files they will simply need to press CTRL+ALT+SHIFT in order to bring up the guacamole menu.
They can then press the shared drive, and upload files to it.

To access the files in the kali browser, they should either use the terminal and cd into "/media/sf_filetransfer"
Or they can open the gui to browse through the folders, it should be on the left side.
![Peek 2021-11-17 15-21](https://user-images.githubusercontent.com/36157675/142218210-eb146f47-78e9-44dd-9c0c-adc8581470fc.gif)

On the more technical side.
Haaukins a new config variable has been made and should be inside the config.yml file.
```
file-transfer-root:
  path: "/path/to/desired/filetransferroot"
```

Haaukins will automatically create the filetransferroot folder on startup, this folder will persist.
When a new event is created, a new folder within the filetransferroot will be created specifically for that event.
And within the event folder user folders will be created when users signup for the event.

Haaukins will then automatically link the each user folder to the corrosponding users vm by utilizing virtualbox shared folders.

On event deletion via the webclient, the event folder including all the user folders will be deleted for that partictular event
  


