### PR TITLE
Added dynamic docker user on guacd container

### DIFF
--- a/daemon/event.go
+++ b/daemon/event.go
@@ -707,6 +707,7 @@ func (d *daemon) closeEvent(ch chan guacamole.Event, wg *sync.WaitGroup) error {
 			currentTime := strconv.Itoa(int(time.Now().Unix()))
 			newEventTag := fmt.Sprintf("%s-%s", e.Tag, currentTime)
 			event, err := d.eventPool.GetEvent(e.Tag)
+			_ = vbox.RemoveEventFolder(string(e.Tag))
 			if err != nil {
 				log.Warn().Msgf("event pool get event error %v ", err)
 				closeErr = err

--- a/svcs/guacamole/event.go
+++ b/svcs/guacamole/event.go
@@ -749,10 +749,9 @@ func (ev *event) createGuacConn(t *store.Team, lab lab.Lab) error {
 
 	instanceInfo := lab.InstanceInfo()
 	// Will not handle error below since this is not a critical function
-	vbox.CreateUserFolder(t.ID(), string(ev.store.Tag))
+	_ = vbox.CreateUserFolder(t.ID(), string(ev.store.Tag))
 
-	vbox.CreateFolderLink(instanceInfo[0].Id, string(ev.store.Tag), t.ID())
-
+	_ = vbox.CreateFolderLink(instanceInfo[0].Id, string(ev.store.Tag), t.ID())
 
 	return nil
 }

--- a/svcs/guacamole/guacamole.go
+++ b/svcs/guacamole/guacamole.go
@@ -165,7 +165,7 @@ func (guac *guacamole) create(ctx context.Context, eventTag string) error {
 		Mounts: []string{
 			vbox.FileTransferRoot + "/" + eventTag + "/:/home/",
 		},
-		User: uid + ":" + gid,
+		User: user
 	})
 
 	mysqlPass := uuid.New().String()

--- a/svcs/guacamole/guacamole.go
+++ b/svcs/guacamole/guacamole.go
@@ -150,7 +150,7 @@ func (guac *guacamole) GetAdminPass() string {
 func (guac *guacamole) create(ctx context.Context, eventTag string) error {
 	err := vbox.CreateEventFolder(eventTag)
 	if err != nil {
-		return err
+		// Do nothing
 	}
 
 	uid := strconv.Itoa(os.Getuid())

--- a/svcs/guacamole/guacamole.go
+++ b/svcs/guacamole/guacamole.go
@@ -148,8 +148,7 @@ func (guac *guacamole) GetAdminPass() string {
 
 //TODO choose another path for mount, Create new path when making a new event.
 func (guac *guacamole) create(ctx context.Context, eventTag string) error {
-	err := vbox.CreateEventFolder(eventTag)
-	if err != nil {
+	_ := vbox.CreateEventFolder(eventTag)
 		// Do nothing
 	}
 

--- a/svcs/guacamole/guacamole.go
+++ b/svcs/guacamole/guacamole.go
@@ -152,9 +152,8 @@ func (guac *guacamole) create(ctx context.Context, eventTag string) error {
 		// Do nothing
 	}
 
-	uid := strconv.Itoa(os.Getuid())
-	gid := strconv.Itoa(os.Getgid())
-	log.Debug().Msgf("Starting guacd as: %s:%s", uid, gid)
+        user := fmt.Sprintf("%d:%d", os.Getuid(),os.Getgid())
+	log.Debug().Str("user", user).Msg("starting guacd")
 
 	containers := map[string]docker.Container{}
 	containers["guacd"] = docker.NewContainer(docker.ContainerConfig{

--- a/svcs/guacamole/guacamole.go
+++ b/svcs/guacamole/guacamole.go
@@ -150,7 +150,7 @@ func (guac *guacamole) GetAdminPass() string {
 func (guac *guacamole) create(ctx context.Context, eventTag string) error {
 	_ := vbox.CreateEventFolder(eventTag)
 		// Do nothing
-	}
+	
 
         user := fmt.Sprintf("%d:%d", os.Getuid(),os.Getgid())
 	log.Debug().Str("user", user).Msg("starting guacd")

--- a/svcs/guacamole/guacamole.go
+++ b/svcs/guacamole/guacamole.go
@@ -17,7 +17,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -148,11 +147,9 @@ func (guac *guacamole) GetAdminPass() string {
 
 //TODO choose another path for mount, Create new path when making a new event.
 func (guac *guacamole) create(ctx context.Context, eventTag string) error {
-	_ := vbox.CreateEventFolder(eventTag)
-		// Do nothing
-	
+	_ = vbox.CreateEventFolder(eventTag)
 
-        user := fmt.Sprintf("%d:%d", os.Getuid(),os.Getgid())
+	user := fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
 	log.Debug().Str("user", user).Msg("starting guacd")
 
 	containers := map[string]docker.Container{}
@@ -165,7 +162,7 @@ func (guac *guacamole) create(ctx context.Context, eventTag string) error {
 		Mounts: []string{
 			vbox.FileTransferRoot + "/" + eventTag + "/:/home/",
 		},
-		User: user
+		User: user,
 	})
 
 	mysqlPass := uuid.New().String()

--- a/svcs/guacamole/guacamole.go
+++ b/svcs/guacamole/guacamole.go
@@ -16,6 +16,8 @@ import (
 	"net/http/cookiejar"
 	"net/http/httputil"
 	"net/url"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -150,6 +152,11 @@ func (guac *guacamole) create(ctx context.Context, eventTag string) error {
 	if err != nil {
 		return err
 	}
+
+	uid := strconv.Itoa(os.Getuid())
+	gid := strconv.Itoa(os.Getgid())
+	log.Debug().Msgf("Starting guacd as: %s:%s", uid, gid)
+
 	containers := map[string]docker.Container{}
 	containers["guacd"] = docker.NewContainer(docker.ContainerConfig{
 		Image:     "guacamole/guacd:1.2.0",
@@ -160,6 +167,7 @@ func (guac *guacamole) create(ctx context.Context, eventTag string) error {
 		Mounts: []string{
 			vbox.FileTransferRoot + "/" + eventTag + "/:/home/",
 		},
+		User: uid + ":" + gid,
 	})
 
 	mysqlPass := uuid.New().String()

--- a/virtual/docker/docker.go
+++ b/virtual/docker/docker.go
@@ -136,6 +136,7 @@ type ContainerConfig struct {
 	PortBindings map[string]string
 	Labels       map[string]string
 	Mounts       []string
+	User         string
 	Resources    *Resources
 	Cmd          []string
 	DNS          []string
@@ -312,6 +313,7 @@ func (c *container) getCreateConfig() (*docker.CreateContainerOptions, error) {
 	return &docker.CreateContainerOptions{
 		Name: uuid.New().String(),
 		Config: &docker.Config{
+			User:         c.conf.User,
 			Image:        c.conf.Image,
 			Env:          env,
 			Cmd:          c.conf.Cmd,


### PR DESCRIPTION
AS haaukins is not run as root on sec02 and sec01, the guacd container which contains the shared files needed to be run with the same uid and gid as the user running haaukins. This should be fixed with this PR