### PR TITLE
fybab never use latest...

### DIFF
--- a/network/dhcp/dhcp.go
+++ b/network/dhcp/dhcp.go
@@ -50,7 +50,7 @@ func New(format func(n int) string) (*Server, error) {
 		return nil, err
 	}
 	cont := docker.NewContainer(docker.ContainerConfig{
-		Image: "networkboot/dhcpd",
+		Image: "networkboot/dhcpd:1.2.0",
 		Mounts: []string{
 			fmt.Sprintf("%s:/data/dhcpd.conf", confFile),
 		},


### PR DESCRIPTION
Vm's can no longer get network connection after they updated the dhcp image 3 days ago.
Rolling back to 1.2.0