### PR TITLE
fix returned error message and log it properly

### DIFF
--- a/daemon/event.go
+++ b/daemon/event.go
@@ -163,9 +163,17 @@ func (d *daemon) CreateEvent(ctx context.Context, req *pb.CreateEventRequest) (*
 			tags[i] = t
 		}
 		evtag, _ := store.NewTag(req.Tag)
-		finishTime, _ := time.Parse(dbTimeFormat, req.FinishTime)
-		startTime, _ := time.Parse(dbTimeFormat, req.StartTime)
-
+		finishTime, err := time.Parse(dbTimeFormat, req.FinishTime)
+		if err != nil {
+			log.Error().Err(err).Msgf("parsing finish time: %v", err)
+			return nil, errors.New("invalid finish time: please select finish time ! ") 
+		}
+		startTime, err := time.Parse(dbTimeFormat, req.StartTime)
+		if err != nil {
+			log.Error().Msgf("invalid start time: %v", err)
+			return nil, errors.New("invalid start time: please select start time !") 
+		}
+		
 		if isInvalidDate(startTime) {
 			return nil, fmt.Errorf("invalid startTime format %v", startTime)
 		}


### PR DESCRIPTION
Closes #723 

This PR is fixing incorrect order of success and failure messages issue described in the issue #723 

Screenshots to the fix: 

From daemon side: 

![false-msg-fix-daemon](https://user-images.githubusercontent.com/13614433/183609006-a82c592e-cadb-4fcc-9ad8-02adbd413e9c.png)

From webclient side: 


![fix-to-return-false-msg](https://user-images.githubusercontent.com/13614433/183609066-b7cd5334-588d-4da0-82bf-bbe8474c13f6.png)

